### PR TITLE
Escape backslashes when setting the namespace

### DIFF
--- a/src/CLI/CLI.php
+++ b/src/CLI/CLI.php
@@ -108,7 +108,7 @@ class CLI
 
             $input->defaultTo($data['value']);
 
-            $replacements[$placeholder] = $input->prompt();
+            $replacements[$placeholder] = addslashes($input->prompt());
         }
 
         return $replacements;


### PR DESCRIPTION
Actually this prevents for having to enter double backslash manually.