### PR TITLE
Update Bootstrap preset to version 4.3.1

### DIFF
--- a/src/CLI/Scaffolding/Presets/Bootstrap.php
+++ b/src/CLI/Scaffolding/Presets/Bootstrap.php
@@ -21,7 +21,9 @@ class Bootstrap extends Preset
     public function scaffold()
     {
         $this->updateDependencies([
-            "bootstrap-sass" => "^3.3.7",
+            "bootstrap" => "^4.3.1",
+            "jquery"  => "^1.9.1",
+            "popper.js" => "^1.15.0"
         ]);
         $this->updateConfig([
             'bootstrap' => [

--- a/src/CLI/Scaffolding/Presets/stubs/bootstrap/resources/assets/js/bootstrap.js
+++ b/src/CLI/Scaffolding/Presets/stubs/bootstrap/resources/assets/js/bootstrap.js
@@ -4,4 +4,4 @@
  * This single line is all what we need.
  */
 
-require('bootstrap-sass');
+require('bootstrap');

--- a/src/CLI/Scaffolding/Presets/stubs/bootstrap/resources/assets/sass/_settings.scss
+++ b/src/CLI/Scaffolding/Presets/stubs/bootstrap/resources/assets/sass/_settings.scss
@@ -1,875 +1,1104 @@
-$bootstrap-sass-asset-helper: true !default;
-
-//
 // Variables
-// --------------------------------------------------
-
-
-//== Colors
 //
-//## Gray and brand colors for use across Bootstrap.
+// Variables should follow the `$component-state-property-size` formula for
+// consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
 
-$gray-base:              #000 !default;
-$gray-darker:            lighten($gray-base, 13.5%) !default; // #222
-$gray-dark:              lighten($gray-base, 20%) !default;   // #333
-$gray:                   lighten($gray-base, 33.5%) !default; // #555
-$gray-light:             lighten($gray-base, 46.7%) !default; // #777
-$gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
+// Color system
 
-$brand-primary:         darken(#428bca, 6.5%) !default; // #337ab7
-$brand-success:         #5cb85c !default;
-$brand-info:            #5bc0de !default;
-$brand-warning:         #f0ad4e !default;
-$brand-danger:          #d9534f !default;
+// $white   : #fff !default;
+// $gray-100: #f8f9fa !default;
+// $gray-200: #e9ecef !default;
+// $gray-300: #dee2e6 !default;
+// $gray-400: #ced4da !default;
+// $gray-500: #adb5bd !default;
+// $gray-600: #6c757d !default;
+// $gray-700: #495057 !default;
+// $gray-800: #343a40 !default;
+// $gray-900: #212529 !default;
+// $black   : #000 !default;
+
+// $grays: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+// $grays: map-merge(
+//   (
+//     "100": $gray-100,
+//     "200": $gray-200,
+//     "300": $gray-300,
+//     "400": $gray-400,
+//     "500": $gray-500,
+//     "600": $gray-600,
+//     "700": $gray-700,
+//     "800": $gray-800,
+//     "900": $gray-900
+//   ),
+//   $grays
+// );
+
+// $blue  : #007bff !default;
+// $indigo: #6610f2 !default;
+// $purple: #6f42c1 !default;
+// $pink  : #e83e8c !default;
+// $red   : #dc3545 !default;
+// $orange: #fd7e14 !default;
+// $yellow: #ffc107 !default;
+// $green : #28a745 !default;
+// $teal  : #20c997 !default;
+// $cyan  : #17a2b8 !default;
+
+// $colors: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+// $colors: map-merge(
+//   (
+//     "blue"     : $blue,
+//     "indigo"   : $indigo,
+//     "purple"   : $purple,
+//     "pink"     : $pink,
+//     "red"      : $red,
+//     "orange"   : $orange,
+//     "yellow"   : $yellow,
+//     "green"    : $green,
+//     "teal"     : $teal,
+//     "cyan"     : $cyan,
+//     "white"    : $white,
+//     "gray"     : $gray-600,
+//     "gray-dark": $gray-800
+//   ),
+//   $colors
+// );
+
+// $primary  : $blue !default;
+// $secondary: $gray-600 !default;
+// $success  : $green !default;
+// $info     : $cyan !default;
+// $warning  : $yellow !default;
+// $danger   : $red !default;
+// $light    : $gray-100 !default;
+// $dark     : $gray-800 !default;
+
+// $theme-colors: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+// $theme-colors: map-merge(
+//   (
+//     "primary"  : $primary,
+//     "secondary": $secondary,
+//     "success"  : $success,
+//     "info"     : $info,
+//     "warning"  : $warning,
+//     "danger"   : $danger,
+//     "light"    : $light,
+//     "dark"     : $dark
+//   ),
+//   $theme-colors
+// );
+
+// Set a specific jump point for requesting color jumps
+// $theme-color-interval: 8% !default;
+
+// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
+// $yiq-contrasted-threshold: 150 !default;
+
+// Customize the light and dark text colors for use in our YIQ color contrast function.
+// $yiq-text-dark : $gray-900 !default;
+// $yiq-text-light: $white !default;
 
 
-//== Scaffolding
+// Options
 //
-//## Settings for some of the most global styles.
+// Quickly modify global styling by enabling or disabling optional features.
 
-//** Background color for `<body>`.
-$body-bg:               #fff !default;
-//** Global text color on `<body>`.
-$text-color:            $gray-dark !default;
+// $enable-caret                             : true !default;
+// $enable-rounded                           : true !default;
+// $enable-shadows                           : false !default;
+// $enable-gradients                         : false !default;
+// $enable-transitions                       : true !default;
+// $enable-prefers-reduced-motion-media-query: true !default;
+// $enable-grid-classes                      : true !default;
+// $enable-pointer-cursor-for-buttons        : true !default;
+// $enable-responsive-font-sizes             : false !default;
+// $enable-validation-icons                  : true !default;
+// $enable-deprecation-messages              : true !default;
 
-//** Global textual link color.
-$link-color:            $brand-primary !default;
-//** Link hover color set via `darken()` function.
-$link-hover-color:      darken($link-color, 15%) !default;
-//** Link hover decoration.
-$link-hover-decoration: underline !default;
 
-
-//== Typography
+// Spacing
 //
-//## Font, line-height, and color for body text, headings, and more.
+// Control the default styling of most Bootstrap elements by modifying these
+// variables. Mostly focused on spacing.
+// You can add more entries to the $spacers map, should you need more variation.
 
-$font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif !default;
-$font-family-serif:       Georgia, "Times New Roman", Times, serif !default;
-//** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
-$font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace !default;
-$font-family-base:        $font-family-sans-serif !default;
+// $spacer : 1rem !default;
+// $spacers: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+// $spacers: map-merge(
+//   (
+//     0: 0,
+//     1: $spacer * .25,
+//     2: $spacer * .5,
+//     3: $spacer,
+//     4: $spacer * 1.5,
+//     5: $spacer * 3,
+//   ),
+//   $spacers
+// );
 
-$font-size-base:          14px !default;
-$font-size-large:         ceil(($font-size-base * 1.25)) !default; // ~18px
-$font-size-small:         ceil(($font-size-base * 0.85)) !default; // ~12px
+// $negative-spacers: negativify-map($spacers) !default;
 
-$font-size-h1:            floor(($font-size-base * 2.6)) !default; // ~36px
-$font-size-h2:            floor(($font-size-base * 2.15)) !default; // ~30px
-$font-size-h3:            ceil(($font-size-base * 1.7)) !default; // ~24px
-$font-size-h4:            ceil(($font-size-base * 1.25)) !default; // ~18px
-$font-size-h5:            $font-size-base !default;
-$font-size-h6:            ceil(($font-size-base * 0.85)) !default; // ~12px
-
-//** Unit-less `line-height` for use in components like buttons.
-$line-height-base:        1.428571429 !default; // 20/14
-//** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-$line-height-computed:    floor(($font-size-base * $line-height-base)) !default; // ~20px
-
-//** By default, this inherits from the `<body>`.
-$headings-font-family:    inherit !default;
-$headings-font-weight:    500 !default;
-$headings-line-height:    1.1 !default;
-$headings-color:          inherit !default;
-
-
-//== Iconography
+// Body
 //
-//## Specify custom location and filename of the included Glyphicons icon font. Useful for those including Bootstrap via Bower.
+// Settings for the `<body>` element.
 
-//** Load fonts from this directory.
-
-// [converter] If $bootstrap-sass-asset-helper if used, provide path relative to the assets load path.
-// [converter] This is because some asset helpers, such as Sprockets, do not work with file-relative paths.
-$icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/bootstrap/") !default;
-
-//** File name for all font files.
-$icon-font-name:          "glyphicons-halflings-regular" !default;
-//** Element ID within SVG icon file.
-$icon-font-svg-id:        "glyphicons_halflingsregular" !default;
+// $body-bg   : $white !default;
+// $body-color: $gray-900 !default;
 
 
-//== Components
+// Links
 //
-//## Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
+// Style anchor elements.
 
-$padding-base-vertical:     6px !default;
-$padding-base-horizontal:   12px !default;
+// $link-color           : theme-color("primary") !default;
+// $link-decoration      : none !default;
+// $link-hover-color     : darken($link-color, 15%) !default;
+// $link-hover-decoration: underline !default;
+// Darken percentage for links with `.text-*` class (e.g. `.text-success`)
+// $emphasized-link-hover-darken-percentage: 15% !default;
 
-$padding-large-vertical:    10px !default;
-$padding-large-horizontal:  16px !default;
+// $stretched-link-pseudo-element: after !default;
+// $stretched-link-z-index       : 1 !default;
 
-$padding-small-vertical:    5px !default;
-$padding-small-horizontal:  10px !default;
-
-$padding-xs-vertical:       1px !default;
-$padding-xs-horizontal:     5px !default;
-
-$line-height-large:         1.3333333 !default; // extra decimals for Win 8.1 Chrome
-$line-height-small:         1.5 !default;
-
-$border-radius-base:        4px !default;
-$border-radius-large:       6px !default;
-$border-radius-small:       3px !default;
-
-//** Global color for active items (e.g., navs or dropdowns).
-$component-active-color:    #fff !default;
-//** Global background color for active items (e.g., navs or dropdowns).
-$component-active-bg:       $brand-primary !default;
-
-//** Width of the `border` for generating carets that indicate dropdowns.
-$caret-width-base:          4px !default;
-//** Carets increase slightly in size for larger components.
-$caret-width-large:         5px !default;
-
-
-//== Tables
+// Paragraphs
 //
-//## Customizes the `.table` component with basic values, each used across all table variations.
+// Style p element.
 
-//** Padding for `<th>`s and `<td>`s.
-$table-cell-padding:            8px !default;
-//** Padding for cells in `.table-condensed`.
-$table-condensed-cell-padding:  5px !default;
-
-//** Default background color used for all tables.
-$table-bg:                      transparent !default;
-//** Background color used for `.table-striped`.
-$table-bg-accent:               #f9f9f9 !default;
-//** Background color used for `.table-hover`.
-$table-bg-hover:                #f5f5f5 !default;
-$table-bg-active:               $table-bg-hover !default;
-
-//** Border color for table and cell borders.
-$table-border-color:            #ddd !default;
+// $paragraph-margin-bottom: 1rem !default;
 
 
-//== Buttons
+// Grid breakpoints
 //
-//## For each of Bootstrap's buttons, define text, background and border color.
+// Define the minimum dimensions at which your layout will change,
+// adapting to different screen sizes, for use in media queries.
 
-$btn-font-weight:                normal !default;
+// $grid-breakpoints: (
+//   xs: 0,
+//   sm: 576px,
+//   md: 768px,
+//   lg: 992px,
+//   xl: 1200px
+// ) !default;
 
-$btn-default-color:              #333 !default;
-$btn-default-bg:                 #fff !default;
-$btn-default-border:             #ccc !default;
+// @include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
+// @include _assert-starts-at-zero($grid-breakpoints, "$grid-breakpoints");
 
-$btn-primary-color:              #fff !default;
-$btn-primary-bg:                 $brand-primary !default;
-$btn-primary-border:             darken($btn-primary-bg, 5%) !default;
 
-$btn-success-color:              #fff !default;
-$btn-success-bg:                 $brand-success !default;
-$btn-success-border:             darken($btn-success-bg, 5%) !default;
+// Grid containers
+//
+// Define the maximum width of `.container` for different screen sizes.
 
-$btn-info-color:                 #fff !default;
-$btn-info-bg:                    $brand-info !default;
-$btn-info-border:                darken($btn-info-bg, 5%) !default;
+// $container-max-widths: (
+//   sm: 540px,
+//   md: 720px,
+//   lg: 960px,
+//   xl: 1140px
+// ) !default;
 
-$btn-warning-color:              #fff !default;
-$btn-warning-bg:                 $brand-warning !default;
-$btn-warning-border:             darken($btn-warning-bg, 5%) !default;
+// @include _assert-ascending($container-max-widths, "$container-max-widths");
 
-$btn-danger-color:               #fff !default;
-$btn-danger-bg:                  $brand-danger !default;
-$btn-danger-border:              darken($btn-danger-bg, 5%) !default;
 
-$btn-link-disabled-color:        $gray-light !default;
+// Grid columns
+//
+// Set the number of columns and specify the width of the gutters.
+
+// $grid-columns     : 12 !default;
+// $grid-gutter-width: 30px !default;
+
+
+// Container padding
+
+// $container-padding-x: $grid-gutter-width / 2 !default;
+
+
+// Components
+//
+// Define common padding and border radius sizes and more.
+
+// $line-height-lg: 1.5 !default;
+// $line-height-sm: 1.5 !default;
+
+// $border-width: 1px !default;
+// $border-color: $gray-300 !default;
+
+// $border-radius   : .25rem !default;
+// $border-radius-lg: .3rem !default;
+// $border-radius-sm: .2rem !default;
+
+// $rounded-pill: 50rem !default;
+
+// $box-shadow-sm: 0 .125rem .25rem rgba($black, .075) !default;
+// $box-shadow   : 0 .5rem 1rem rgba($black, .15) !default;
+// $box-shadow-lg: 0 1rem 3rem rgba($black, .175) !default;
+
+// $component-active-color: $white !default;
+// $component-active-bg   : theme-color("primary") !default;
+
+// $caret-width         : .3em !default;
+// $caret-vertical-align: $caret-width * .85 !default;
+// $caret-spacing       : $caret-width * .85 !default;
+
+// $transition-base    : all .2s ease-in-out !default;
+// $transition-fade    : opacity .15s linear !default;
+// $transition-collapse: height .35s ease !default;
+
+// $embed-responsive-aspect-ratios: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+// $embed-responsive-aspect-ratios: map-merge(
+//   (
+//     "21by9": (
+//       x: 21,
+//       y: 9
+//     ),
+//     "16by9": (
+//       x: 16,
+//       y: 9
+//     ),
+//     "4by3": (
+//       x: 4,
+//       y: 3
+//     ),
+//     "1by1": (
+//       x: 1,
+//       y: 1
+//     )
+//   ),
+//   $embed-responsive-aspect-ratios
+// );
+
+// Typography
+//
+// Font, line-height, and color for body text, headings, and more.
+
+// stylelint-disable value-keyword-case
+// $font-family-sans-serif: -apple-system,  BlinkMacSystemFont, "Segoe UI", Roboto,   "Helvetica Neue",  Arial,         "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+// $font-family-monospace : SFMono-Regular, Menlo,              Monaco,     Consolas, "Liberation Mono", "Courier New", monospace !default;
+// $font-family-base      : $font-family-sans-serif !default;
+// stylelint-enable value-keyword-case
+
+// $font-size-base: 1rem !default;                    // Assumes the browser default, typically `16px`
+// $font-size-lg  : $font-size-base * 1.25 !default;
+// $font-size-sm  : $font-size-base * .875 !default;
+
+// $font-weight-lighter: lighter !default;
+// $font-weight-light  : 300 !default;
+// $font-weight-normal : 400 !default;
+// $font-weight-bold   : 700 !default;
+// $font-weight-bolder : bolder !default;
+
+// $font-weight-base: $font-weight-normal !default;
+// $line-height-base: 1.5 !default;
+
+// $h1-font-size: $font-size-base * 2.5 !default;
+// $h2-font-size: $font-size-base * 2 !default;
+// $h3-font-size: $font-size-base * 1.75 !default;
+// $h4-font-size: $font-size-base * 1.5 !default;
+// $h5-font-size: $font-size-base * 1.25 !default;
+// $h6-font-size: $font-size-base !default;
+
+// $headings-margin-bottom: $spacer / 2 !default;
+// $headings-font-family  : null !default;
+// $headings-font-style   : null !default;
+// $headings-font-weight  : 500 !default;
+// $headings-line-height  : 1.2 !default;
+// $headings-color        : null !default;
+
+// $display1-size: 6rem !default;
+// $display2-size: 5.5rem !default;
+// $display3-size: 4.5rem !default;
+// $display4-size: 3.5rem !default;
+
+// $display1-weight    : 300 !default;
+// $display2-weight    : 300 !default;
+// $display3-weight    : 300 !default;
+// $display4-weight    : 300 !default;
+// $display-line-height: $headings-line-height !default;
+
+// $lead-font-size  : $font-size-base * 1.25 !default;
+// $lead-font-weight: 300 !default;
+
+// $small-font-size: 80% !default;
+
+// $text-muted: $gray-600 !default;
+
+// $blockquote-small-color    : $gray-600 !default;
+// $blockquote-small-font-size: $small-font-size !default;
+// $blockquote-font-size      : $font-size-base * 1.25 !default;
+
+// $hr-color  : inherit !default;
+// $hr-height : $border-width !default;
+// $hr-opacity: .25 !default;
+
+// $mark-padding: .2em !default;
+
+// $dt-font-weight: $font-weight-bold !default;
+
+// $kbd-box-shadow        : inset 0 -.1rem 0 rgba($black, .25) !default;
+// $nested-kbd-font-weight: $font-weight-bold !default;
+
+// $list-inline-padding: .5rem !default;
+
+// $mark-bg: #fcf8e3 !default;
+
+// $hr-margin-y: $spacer !default;
+
+
+// Tables
+//
+// Customizes the `.table` component with basic values, each used across all table variations.
+
+// $table-cell-padding   : .75rem !default;
+// $table-cell-padding-sm: .3rem !default;
+
+// $table-color      : $body-color !default;
+// $table-bg         : null !default;
+// $table-accent-bg  : rgba($black, .05) !default;
+// $table-hover-color: $table-color !default;
+// $table-hover-bg   : rgba($black, .075) !default;
+// $table-active-bg  : $table-hover-bg !default;
+
+// $table-border-width: $border-width !default;
+// $table-border-color: $border-color !default;
+
+// $table-head-bg   : $gray-200 !default;
+// $table-head-color: $gray-700 !default;
+
+// $table-dark-color       : $white !default;
+// $table-dark-bg          : $gray-800 !default;
+// $table-dark-accent-bg   : rgba($white, .05) !default;
+// $table-dark-hover-color : $table-dark-color !default;
+// $table-dark-hover-bg    : rgba($white, .075) !default;
+// $table-dark-border-color: lighten($table-dark-bg, 7.5%) !default;
+
+// $table-striped-order: odd !default;
+
+// $table-caption-color: $text-muted !default;
+
+// $table-bg-level    : -9 !default;
+// $table-border-level: -6 !default;
+
+
+// Buttons + Forms
+//
+// Shared variables that are reassigned to `$input-` and `$btn-` specific variables.
+
+// $input-btn-padding-y  : .375rem !default;
+// $input-btn-padding-x  : .75rem !default;
+// $input-btn-font-family: null !default;
+// $input-btn-font-size  : $font-size-base !default;
+// $input-btn-line-height: $line-height-base !default;
+
+// $input-btn-focus-width     : .2rem !default;
+// $input-btn-focus-color     : rgba($component-active-bg, .25) !default;
+// $input-btn-focus-box-shadow: 0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
+
+// $input-btn-padding-y-sm  : .25rem !default;
+// $input-btn-padding-x-sm  : .5rem !default;
+// $input-btn-font-size-sm  : $font-size-sm !default;
+// $input-btn-line-height-sm: $line-height-sm !default;
+
+// $input-btn-padding-y-lg  : .5rem !default;
+// $input-btn-padding-x-lg  : 1rem !default;
+// $input-btn-font-size-lg  : $font-size-lg !default;
+// $input-btn-line-height-lg: $line-height-lg !default;
+
+// $input-btn-border-width: $border-width !default;
+
+
+// Buttons
+//
+// For each of Bootstrap's buttons, define text, background, and border color.
+
+// $btn-padding-y  : $input-btn-padding-y !default;
+// $btn-padding-x  : $input-btn-padding-x !default;
+// $btn-font-family: $input-btn-font-family !default;
+// $btn-font-size  : $input-btn-font-size !default;
+// $btn-line-height: $input-btn-line-height !default;
+
+// $btn-padding-y-sm  : $input-btn-padding-y-sm !default;
+// $btn-padding-x-sm  : $input-btn-padding-x-sm !default;
+// $btn-font-size-sm  : $input-btn-font-size-sm !default;
+// $btn-line-height-sm: $input-btn-line-height-sm !default;
+
+// $btn-padding-y-lg  : $input-btn-padding-y-lg !default;
+// $btn-padding-x-lg  : $input-btn-padding-x-lg !default;
+// $btn-font-size-lg  : $input-btn-font-size-lg !default;
+// $btn-line-height-lg: $input-btn-line-height-lg !default;
+
+// $btn-border-width: $input-btn-border-width !default;
+
+// $btn-font-weight      : $font-weight-normal !default;
+// $btn-box-shadow       : inset 0 1px 0 rgba($white, .15), 0 1px 1px rgba($black, .075) !default;
+// $btn-focus-width      : $input-btn-focus-width !default;
+// $btn-focus-box-shadow : $input-btn-focus-box-shadow !default;
+// $btn-disabled-opacity : .65 !default;
+// $btn-active-box-shadow: inset 0 3px 5px rgba($black, .125) !default;
+
+// $btn-link-color         : $link-color !default;
+// $btn-link-hover-color   : $link-hover-color !default;
+// $btn-link-disabled-color: $gray-600 !default;
+
+// $btn-block-spacing-y: .5rem !default;
 
 // Allows for customizing button radius independently from global border radius
-$btn-border-radius-base:         $border-radius-base !default;
-$btn-border-radius-large:        $border-radius-large !default;
-$btn-border-radius-small:        $border-radius-small !default;
+// $btn-border-radius   : $border-radius !default;
+// $btn-border-radius-lg: $border-radius-lg !default;
+// $btn-border-radius-sm: $border-radius-sm !default;
+
+// $btn-transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 
 
-//== Forms
-//
-//##
+// Forms
 
-//** `<input>` background color
-$input-bg:                       #fff !default;
-//** `<input disabled>` background color
-$input-bg-disabled:              $gray-lighter !default;
+// $label-margin-bottom: .5rem !default;
 
-//** Text color for `<input>`s
-$input-color:                    $gray !default;
-//** `<input>` border color
-$input-border:                   #ccc !default;
+// $input-padding-y  : $input-btn-padding-y !default;
+// $input-padding-x  : $input-btn-padding-x !default;
+// $input-font-family: $input-btn-font-family !default;
+// $input-font-size  : $input-btn-font-size !default;
+// $input-font-weight: $font-weight-base !default;
+// $input-line-height: $input-btn-line-height !default;
 
-// TODO: Rename `$input-border-radius` to `$input-border-radius-base` in v4
-//** Default `.form-control` border radius
-// This has no effect on `<select>`s in some browsers, due to the limited stylability of `<select>`s in CSS.
-$input-border-radius:            $border-radius-base !default;
-//** Large `.form-control` border radius
-$input-border-radius-large:      $border-radius-large !default;
-//** Small `.form-control` border radius
-$input-border-radius-small:      $border-radius-small !default;
+// $input-padding-y-sm  : $input-btn-padding-y-sm !default;
+// $input-padding-x-sm  : $input-btn-padding-x-sm !default;
+// $input-font-size-sm  : $input-btn-font-size-sm !default;
+// $input-line-height-sm: $input-btn-line-height-sm !default;
 
-//** Border color for inputs on focus
-$input-border-focus:             #66afe9 !default;
+// $input-padding-y-lg  : $input-btn-padding-y-lg !default;
+// $input-padding-x-lg  : $input-btn-padding-x-lg !default;
+// $input-font-size-lg  : $input-btn-font-size-lg !default;
+// $input-line-height-lg: $input-btn-line-height-lg !default;
 
-//** Placeholder text color
-$input-color-placeholder:        #999 !default;
+// $input-bg         : $white !default;
+// $input-disabled-bg: $gray-200 !default;
 
-//** Default `.form-control` height
-$input-height-base:              ($line-height-computed + ($padding-base-vertical * 2) + 2) !default;
-//** Large `.form-control` height
-$input-height-large:             (ceil($font-size-large * $line-height-large) + ($padding-large-vertical * 2) + 2) !default;
-//** Small `.form-control` height
-$input-height-small:             (floor($font-size-small * $line-height-small) + ($padding-small-vertical * 2) + 2) !default;
+// $input-color       : $gray-700 !default;
+// $input-border-color: $gray-400 !default;
+// $input-border-width: $input-btn-border-width !default;
+// $input-box-shadow  : inset 0 1px 1px rgba($black, .075) !default;
 
-//** `.form-group` margin
-$form-group-margin-bottom:       15px !default;
+// $input-border-radius   : $border-radius !default;
+// $input-border-radius-lg: $border-radius-lg !default;
+// $input-border-radius-sm: $border-radius-sm !default;
 
-$legend-color:                   $gray-dark !default;
-$legend-border-color:            #e5e5e5 !default;
+// $input-focus-bg          : $input-bg !default;
+// $input-focus-border-color: lighten($component-active-bg, 25%) !default;
+// $input-focus-color       : $input-color !default;
+// $input-focus-width       : $input-btn-focus-width !default;
+// $input-focus-box-shadow  : $input-btn-focus-box-shadow !default;
 
-//** Background color for textual input addons
-$input-group-addon-bg:           $gray-lighter !default;
-//** Border color for textual input addons
-$input-group-addon-border-color: $input-border !default;
+// $input-placeholder-color: $gray-600 !default;
+// $input-plaintext-color  : $body-color !default;
 
-//** Disabled cursor for form controls and buttons.
-$cursor-disabled:                not-allowed !default;
+// $input-height-border: $input-border-width * 2 !default;
+
+// $input-height-inner        : calc(#{$input-line-height * 1em} + #{$input-padding-y * 2}) !default;
+// $input-height-inner-half   : calc(#{$input-line-height * .5em} + #{$input-padding-y}) !default;
+// $input-height-inner-quarter: calc(#{$input-line-height * .25em} + #{$input-padding-y / 2}) !default;
+
+// $input-height   : calc(#{$input-line-height * 1em} + #{$input-padding-y * 2} + #{$input-height-border}) !default;
+// $input-height-sm: calc(#{$input-line-height-sm * 1em} + #{$input-btn-padding-y-sm * 2} + #{$input-height-border}) !default;
+// $input-height-lg: calc(#{$input-line-height-lg * 1em} + #{$input-btn-padding-y-lg * 2} + #{$input-height-border}) !default;
+
+// $input-transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+
+// $form-text-margin-top: .25rem !default;
+
+// $form-check-input-gutter  : 1.25rem !default;
+// $form-check-input-margin-y: .3rem !default;
+// $form-check-input-margin-x: .25rem !default;
+
+// $form-check-inline-margin-x      : .75rem !default;
+// $form-check-inline-input-margin-x: .3125rem !default;
+
+// $form-grid-gutter-width  : 10px !default;
+// $form-group-margin-bottom: 1rem !default;
+
+// $input-group-addon-color       : $input-color !default;
+// $input-group-addon-bg          : $gray-200 !default;
+// $input-group-addon-border-color: $input-border-color !default;
+
+// $custom-forms-transition: background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+
+// $custom-control-gutter  : .5rem !default;
+// $custom-control-spacer-x: 1rem !default;
+
+// $custom-control-indicator-size: 1rem !default;
+// $custom-control-indicator-bg  : $input-bg !default;
+
+// $custom-control-indicator-bg-size     : 50% 50% !default;
+// $custom-control-indicator-box-shadow  : $input-box-shadow !default;
+// $custom-control-indicator-border-color: $gray-500 !default;
+// $custom-control-indicator-border-width: $input-border-width !default;
+
+// $custom-control-label-color: null !default;
+
+// $custom-control-indicator-disabled-bg: $input-disabled-bg !default;
+// $custom-control-label-disabled-color : $gray-600 !default;
+
+// $custom-control-indicator-checked-color       : $component-active-color !default;
+// $custom-control-indicator-checked-bg          : $component-active-bg !default;
+// $custom-control-indicator-checked-disabled-bg : rgba(theme-color("primary"), .5) !default;
+// $custom-control-indicator-checked-box-shadow  : none !default;
+// $custom-control-indicator-checked-border-color: $custom-control-indicator-checked-bg !default;
+
+// $custom-control-indicator-focus-box-shadow  : $input-focus-box-shadow !default;
+// $custom-control-indicator-focus-border-color: $input-focus-border-color !default;
+
+// $custom-control-indicator-active-color       : $component-active-color !default;
+// $custom-control-indicator-active-bg          : lighten($component-active-bg, 35%) !default;
+// $custom-control-indicator-active-box-shadow  : none !default;
+// $custom-control-indicator-active-border-color: $custom-control-indicator-active-bg !default;
+
+// $custom-checkbox-indicator-border-radius: $border-radius !default;
+// $custom-checkbox-indicator-icon-checked : str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='#{$custom-control-indicator-checked-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e"), "#", "%23") !default;
+
+// $custom-checkbox-indicator-indeterminate-bg          : $component-active-bg !default;
+// $custom-checkbox-indicator-indeterminate-color       : $custom-control-indicator-checked-color !default;
+// $custom-checkbox-indicator-icon-indeterminate        : str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='#{$custom-checkbox-indicator-indeterminate-color}' d='M0 2h4'/%3e%3c/svg%3e"), "#", "%23") !default;
+// $custom-checkbox-indicator-indeterminate-box-shadow  : none !default;
+// $custom-checkbox-indicator-indeterminate-border-color: $custom-checkbox-indicator-indeterminate-bg !default;
+
+// $custom-radio-indicator-border-radius: 50% !default;
+// $custom-radio-indicator-icon-checked : str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='#{$custom-control-indicator-checked-color}'/%3e%3c/svg%3e"), "#", "%23") !default;
+
+// $custom-switch-width                  : $custom-control-indicator-size * 1.75 !default;
+// $custom-switch-indicator-border-radius: $custom-control-indicator-size / 2 !default;
+// $custom-switch-indicator-size         : calc(#{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4}) !default;
+
+// $custom-select-padding-y        : $input-padding-y !default;
+// $custom-select-padding-x        : $input-padding-x !default;
+// $custom-select-font-family      : $input-font-family !default;
+// $custom-select-font-size        : $input-font-size !default;
+// $custom-select-height           : $input-height !default;
+// $custom-select-indicator-padding: 1rem !default;                                                                                                                                                                                                        // Extra padding to account for the presence of the background-image based indicator
+// $custom-select-font-weight      : $input-font-weight !default;
+// $custom-select-line-height      : $input-line-height !default;
+// $custom-select-color            : $input-color !default;
+// $custom-select-disabled-color   : $gray-600 !default;
+// $custom-select-bg               : $input-bg !default;
+// $custom-select-disabled-bg      : $gray-200 !default;
+// $custom-select-bg-size          : 8px 10px !default;                                                                                                                                                                                                    // In pixels because image dimensions
+// $custom-select-indicator-color  : $gray-800 !default;
+// $custom-select-indicator        : str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='#{$custom-select-indicator-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e"), "#", "%23") !default;
+// $custom-select-background       : $custom-select-indicator no-repeat right $custom-select-padding-x center / $custom-select-bg-size !default;                                                                                                           // Used so we can have multiple background elements (e.g., arrow and feedback icon)
+
+// $custom-select-feedback-icon-padding-right: calc((1em + #{2 * $custom-select-padding-y}) * 3 / 4 + #{$custom-select-padding-x + $custom-select-indicator-padding}) !default;
+// $custom-select-feedback-icon-position     : center right ($custom-select-padding-x + $custom-select-indicator-padding) !default;
+// $custom-select-feedback-icon-size         : $input-height-inner-half $input-height-inner-half !default;
+
+// $custom-select-border-width : $input-border-width !default;
+// $custom-select-border-color : $input-border-color !default;
+// $custom-select-border-radius: $border-radius !default;
+// $custom-select-box-shadow   : inset 0 1px 2px rgba($black, .075) !default;
+
+// $custom-select-focus-border-color: $input-focus-border-color !default;
+// $custom-select-focus-width       : $input-focus-width !default;
+// $custom-select-focus-box-shadow  : 0 0 0 $custom-select-focus-width $input-btn-focus-color !default;
+
+// $custom-select-padding-y-sm: $input-padding-y-sm !default;
+// $custom-select-padding-x-sm: $input-padding-x-sm !default;
+// $custom-select-font-size-sm: $input-font-size-sm !default;
+// $custom-select-height-sm   : $input-height-sm !default;
+
+// $custom-select-padding-y-lg: $input-padding-y-lg !default;
+// $custom-select-padding-x-lg: $input-padding-x-lg !default;
+// $custom-select-font-size-lg: $input-font-size-lg !default;
+// $custom-select-height-lg   : $input-height-lg !default;
+
+// $custom-range-track-width        : 100% !default;
+// $custom-range-track-height       : .5rem !default;
+// $custom-range-track-cursor       : pointer !default;
+// $custom-range-track-bg           : $gray-300 !default;
+// $custom-range-track-border-radius: 1rem !default;
+// $custom-range-track-box-shadow   : inset 0 .25rem .25rem rgba($black, .1) !default;
+
+// $custom-range-thumb-width                 : 1rem !default;
+// $custom-range-thumb-height                : $custom-range-thumb-width !default;
+// $custom-range-thumb-bg                    : $component-active-bg !default;
+// $custom-range-thumb-border                : 0 !default;
+// $custom-range-thumb-border-radius         : 1rem !default;
+// $custom-range-thumb-box-shadow            : 0 .1rem .25rem rgba($black, .1) !default;
+// $custom-range-thumb-focus-box-shadow      : 0 0 0 1px $body-bg, $input-focus-box-shadow !default;
+// $custom-range-thumb-focus-box-shadow-width: $input-focus-width !default;                           // For focus box shadow issue in IE/Edge
+// $custom-range-thumb-active-bg             : lighten($component-active-bg, 35%) !default;
+// $custom-range-thumb-disabled-bg           : $gray-500 !default;
+
+// $custom-file-height            : $input-height !default;
+// $custom-file-focus-border-color: $input-focus-border-color !default;
+// $custom-file-focus-box-shadow  : $input-focus-box-shadow !default;
+// $custom-file-disabled-bg       : $input-disabled-bg !default;
+
+// $custom-file-padding-y    : $input-padding-y !default;
+// $custom-file-padding-x    : $input-padding-x !default;
+// $custom-file-line-height  : $input-line-height !default;
+// $custom-file-font-family  : $input-font-family !default;
+// $custom-file-font-weight  : $input-font-weight !default;
+// $custom-file-color        : $input-color !default;
+// $custom-file-bg           : $input-bg !default;
+// $custom-file-border-width : $input-border-width !default;
+// $custom-file-border-color : $input-border-color !default;
+// $custom-file-border-radius: $input-border-radius !default;
+// $custom-file-box-shadow   : $input-box-shadow !default;
+// $custom-file-button-color : $custom-file-color !default;
+// $custom-file-button-bg    : $input-group-addon-bg !default;
 
 
-//== Dropdowns
-//
-//## Dropdown menu container and contents.
+// Form validation
 
-//** Background for the dropdown menu.
-$dropdown-bg:                    #fff !default;
-//** Dropdown menu `border-color`.
-$dropdown-border:                rgba(0,0,0,.15) !default;
-//** Dropdown menu `border-color` **for IE8**.
-$dropdown-fallback-border:       #ccc !default;
-//** Divider color for between dropdown items.
-$dropdown-divider-bg:            #e5e5e5 !default;
+// $form-feedback-margin-top   : $form-text-margin-top !default;
+// $form-feedback-font-size    : $small-font-size !default;
+// $form-feedback-valid-color  : theme-color("success") !default;
+// $form-feedback-invalid-color: theme-color("danger") !default;
 
-//** Dropdown link text color.
-$dropdown-link-color:            $gray-dark !default;
-//** Hover color for dropdown links.
-$dropdown-link-hover-color:      darken($gray-dark, 5%) !default;
-//** Hover background for dropdown links.
-$dropdown-link-hover-bg:         #f5f5f5 !default;
+// $form-feedback-icon-valid-color  : $form-feedback-valid-color !default;
+// $form-feedback-icon-valid        : str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='#{$form-feedback-icon-valid-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e"), "#", "%23") !default;
+// $form-feedback-icon-invalid-color: $form-feedback-invalid-color !default;
+// $form-feedback-icon-invalid      : str-replace(url("data:image/svg+xml,%3csvg width='12' height='12' viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg' stroke='#{$form-feedback-icon-invalid-color}' fill='none'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath d='M5.8 3.6h.4L6 6.5z' stroke-linejoin='round'/%3e%3ccircle cx='6' cy='8.2' r='.1'/%3e%3c/svg%3e"), "#", "%23") !default;
 
-//** Active dropdown menu item text color.
-$dropdown-link-active-color:     $component-active-color !default;
-//** Active dropdown menu item background color.
-$dropdown-link-active-bg:        $component-active-bg !default;
+// $form-validation-states: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+// $form-validation-states: map-merge(
+//   (
+//     "valid": (
+//       "color": $form-feedback-valid-color,
+//       "icon" : $form-feedback-icon-valid
+//     ),
+//     "invalid": (
+//       "color": $form-feedback-invalid-color,
+//       "icon" : $form-feedback-icon-invalid
+//     ),
+//   ),
+//   $form-validation-states
+// );
 
-//** Disabled dropdown menu item background color.
-$dropdown-link-disabled-color:   $gray-light !default;
-
-//** Text color for headers within dropdown menus.
-$dropdown-header-color:          $gray-light !default;
-
-//** Deprecated `$dropdown-caret-color` as of v3.1.0
-$dropdown-caret-color:           #000 !default;
-
-
-//-- Z-index master list
+// Z-index master list
 //
 // Warning: Avoid customizing these values. They're used for a bird's eye view
 // of components dependent on the z-axis and are designed to all work together.
+
+// $zindex-dropdown      : 1000 !default;
+// $zindex-sticky        : 1020 !default;
+// $zindex-fixed         : 1030 !default;
+// $zindex-modal-backdrop: 1040 !default;
+// $zindex-modal         : 1050 !default;
+// $zindex-popover       : 1060 !default;
+// $zindex-tooltip       : 1070 !default;
+
+
+// Navs
+
+// $nav-link-padding-y     : .5rem !default;
+// $nav-link-padding-x     : 1rem !default;
+// $nav-link-disabled-color: $gray-600 !default;
+
+// $nav-tabs-border-color            : $gray-300 !default;
+// $nav-tabs-border-width            : $border-width !default;
+// $nav-tabs-border-radius           : $border-radius !default;
+// $nav-tabs-link-hover-border-color : $gray-200 $gray-200 $nav-tabs-border-color !default;
+// $nav-tabs-link-active-color       : $gray-700 !default;
+// $nav-tabs-link-active-bg          : $body-bg !default;
+// $nav-tabs-link-active-border-color: $gray-300 $gray-300 $nav-tabs-link-active-bg !default;
+
+// $nav-pills-border-radius    : $border-radius !default;
+// $nav-pills-link-active-color: $component-active-color !default;
+// $nav-pills-link-active-bg   : $component-active-bg !default;
+
+// $nav-divider-color   : $gray-200 !default;
+// $nav-divider-margin-y: $spacer / 2 !default;
+
+
+// Navbar
+
+// $navbar-padding-y: $spacer / 2 !default;
+// $navbar-padding-x: $spacer !default;
+
+// $navbar-nav-link-padding-x: .5rem !default;
+
+// $navbar-brand-font-size: $font-size-lg !default;
+// Compute the navbar-brand padding-y so the navbar-brand will have the same height as navbar-text and nav-link
+// $nav-link-height       : $font-size-base * $line-height-base + $nav-link-padding-y * 2 !default;
+// $navbar-brand-height   : $navbar-brand-font-size * $line-height-base !default;
+// $navbar-brand-padding-y: ($nav-link-height - $navbar-brand-height) / 2 !default;
+
+// $navbar-toggler-padding-y    : .25rem !default;
+// $navbar-toggler-padding-x    : .75rem !default;
+// $navbar-toggler-font-size    : $font-size-lg !default;
+// $navbar-toggler-border-radius: $btn-border-radius !default;
+
+// $navbar-dark-color               : rgba($white, .5) !default;
+// $navbar-dark-hover-color         : rgba($white, .75) !default;
+// $navbar-dark-active-color        : $white !default;
+// $navbar-dark-disabled-color      : rgba($white, .25) !default;
+// $navbar-dark-toggler-icon-bg     : str-replace(url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e"), "#", "%23") !default;
+// $navbar-dark-toggler-border-color: rgba($white, .1) !default;
+
+// $navbar-light-color               : rgba($black, .5) !default;
+// $navbar-light-hover-color         : rgba($black, .7) !default;
+// $navbar-light-active-color        : rgba($black, .9) !default;
+// $navbar-light-disabled-color      : rgba($black, .3) !default;
+// $navbar-light-toggler-icon-bg     : str-replace(url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='#{$navbar-light-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e"), "#", "%23") !default;
+// $navbar-light-toggler-border-color: rgba($black, .1) !default;
+
+// $navbar-light-brand-color      : $navbar-light-active-color !default;
+// $navbar-light-brand-hover-color: $navbar-light-active-color !default;
+// $navbar-dark-brand-color       : $navbar-dark-active-color !default;
+// $navbar-dark-brand-hover-color : $navbar-dark-active-color !default;
+
+
+// Dropdowns
 //
-// Note: These variables are not generated into the Customizer.
+// Dropdown menu container and contents.
 
-$zindex-navbar:            1000 !default;
-$zindex-dropdown:          1000 !default;
-$zindex-popover:           1060 !default;
-$zindex-tooltip:           1070 !default;
-$zindex-navbar-fixed:      1030 !default;
-$zindex-modal-background:  1040 !default;
-$zindex-modal:             1050 !default;
+// $dropdown-min-width          : 10rem !default;
+// $dropdown-padding-y          : .5rem !default;
+// $dropdown-spacer             : .125rem !default;
+// $dropdown-font-size          : $font-size-base !default;
+// $dropdown-color              : $body-color !default;
+// $dropdown-bg                 : $white !default;
+// $dropdown-border-color       : rgba($black, .15) !default;
+// $dropdown-border-radius      : $border-radius !default;
+// $dropdown-border-width       : $border-width !default;
+// $dropdown-inner-border-radius: calc(#{$dropdown-border-radius} - #{$dropdown-border-width}) !default;
+// $dropdown-divider-bg         : $gray-200 !default;
+// $dropdown-divider-margin-y   : $nav-divider-margin-y !default;
+// $dropdown-box-shadow         : 0 .5rem 1rem rgba($black, .175) !default;
+
+// $dropdown-link-color      : $gray-900 !default;
+// $dropdown-link-hover-color: darken($gray-900, 5%) !default;
+// $dropdown-link-hover-bg   : $gray-100 !default;
+
+// $dropdown-link-active-color: $component-active-color !default;
+// $dropdown-link-active-bg   : $component-active-bg !default;
+
+// $dropdown-link-disabled-color: $gray-600 !default;
+
+// $dropdown-item-padding-y: .25rem !default;
+// $dropdown-item-padding-x: 1.5rem !default;
+
+// $dropdown-header-color: $gray-600 !default;
 
 
-//== Media queries breakpoints
+// Pagination
+
+// $pagination-padding-y   : .5rem !default;
+// $pagination-padding-x   : .75rem !default;
+// $pagination-padding-y-sm: .25rem !default;
+// $pagination-padding-x-sm: .5rem !default;
+// $pagination-padding-y-lg: .75rem !default;
+// $pagination-padding-x-lg: 1.5rem !default;
+// $pagination-line-height : 1.25 !default;
+
+// $pagination-color       : $link-color !default;
+// $pagination-bg          : $white !default;
+// $pagination-border-width: $border-width !default;
+// $pagination-border-color: $gray-300 !default;
+
+// $pagination-focus-box-shadow: $input-btn-focus-box-shadow !default;
+// $pagination-focus-outline   : 0 !default;
+
+// $pagination-hover-color       : $link-hover-color !default;
+// $pagination-hover-bg          : $gray-200 !default;
+// $pagination-hover-border-color: $gray-300 !default;
+
+// $pagination-active-color       : $component-active-color !default;
+// $pagination-active-bg          : $component-active-bg !default;
+// $pagination-active-border-color: $pagination-active-bg !default;
+
+// $pagination-disabled-color       : $gray-600 !default;
+// $pagination-disabled-bg          : $white !default;
+// $pagination-disabled-border-color: $gray-300 !default;
+
+
+// Cards
+
+// $card-spacer-y           : .75rem !default;
+// $card-spacer-x           : 1.25rem !default;
+// $card-border-width       : $border-width !default;
+// $card-border-radius      : $border-radius !default;
+// $card-border-color       : rgba($black, .125) !default;
+// $card-inner-border-radius: calc(#{$card-border-radius} - #{$card-border-width}) !default;
+// $card-cap-bg             : rgba($black, .03) !default;
+// $card-cap-color          : null !default;
+// $card-color              : null !default;
+// $card-bg                 : $white !default;
+
+// $card-img-overlay-padding: 1.25rem !default;
+
+// $card-group-margin: $grid-gutter-width / 2 !default;
+// $card-deck-margin : $card-group-margin !default;
+
+// $card-columns-count : 3 !default;
+// $card-columns-gap   : 1.25rem !default;
+// $card-columns-margin: $card-spacer-y !default;
+
+
+// Tooltips
+
+// $tooltip-font-size    : $font-size-sm !default;
+// $tooltip-max-width    : 200px !default;
+// $tooltip-color        : $white !default;
+// $tooltip-bg           : $black !default;
+// $tooltip-border-radius: $border-radius !default;
+// $tooltip-opacity      : .9 !default;
+// $tooltip-padding-y    : .25rem !default;
+// $tooltip-padding-x    : .5rem !default;
+// $tooltip-margin       : 0 !default;
+
+// $tooltip-arrow-width : .8rem !default;
+// $tooltip-arrow-height: .4rem !default;
+// $tooltip-arrow-color : $tooltip-bg !default;
+
+// Form tooltips must come after regular tooltips
+// $form-feedback-tooltip-padding-y    : $tooltip-padding-y !default;
+// $form-feedback-tooltip-padding-x    : $tooltip-padding-x !default;
+// $form-feedback-tooltip-font-size    : $tooltip-font-size !default;
+// $form-feedback-tooltip-line-height  : $line-height-base !default;
+// $form-feedback-tooltip-opacity      : $tooltip-opacity !default;
+// $form-feedback-tooltip-border-radius: $tooltip-border-radius !default;
+
+
+// Popovers
+
+// $popover-font-size          : $font-size-sm !default;
+// $popover-bg                 : $white !default;
+// $popover-max-width          : 276px !default;
+// $popover-border-width       : $border-width !default;
+// $popover-border-color       : rgba($black, .2) !default;
+// $popover-border-radius      : $border-radius-lg !default;
+// $popover-inner-border-radius: calc(#{$popover-border-radius} - #{$popover-border-width}) !default;
+// $popover-box-shadow         : 0 .25rem .5rem rgba($black, .2) !default;
+
+// $popover-header-bg       : darken($popover-bg, 3%) !default;
+// $popover-header-color    : $headings-color !default;
+// $popover-header-padding-y: .5rem !default;
+// $popover-header-padding-x: .75rem !default;
+
+// $popover-body-color    : $body-color !default;
+// $popover-body-padding-y: $popover-header-padding-y !default;
+// $popover-body-padding-x: $popover-header-padding-x !default;
+
+// $popover-arrow-width : 1rem !default;
+// $popover-arrow-height: .5rem !default;
+// $popover-arrow-color : $popover-bg !default;
+
+// $popover-arrow-outer-color: fade-in($popover-border-color, .05) !default;
+
+
+// Toasts
+
+// $toast-max-width       : 350px !default;
+// $toast-padding-x       : .75rem !default;
+// $toast-padding-y       : .25rem !default;
+// $toast-font-size       : .875rem !default;
+// $toast-color           : null !default;
+// $toast-background-color: rgba($white, .85) !default;
+// $toast-border-width    : 1px !default;
+// $toast-border-color    : rgba(0, 0, 0, .1) !default;
+// $toast-border-radius   : $border-radius !default;
+// $toast-box-shadow      : 0 .25rem .75rem rgba($black, .1) !default;
+
+// $toast-header-color           : $gray-600 !default;
+// $toast-header-background-color: rgba($white, .85) !default;
+// $toast-header-border-color    : rgba(0, 0, 0, .05) !default;
+
+
+// Badges
+
+// $badge-font-size    : 75% !default;
+// $badge-font-weight  : $font-weight-bold !default;
+// $badge-color        : $white !default;
+// $badge-padding-y    : .25em !default;
+// $badge-padding-x    : .5em !default;
+// $badge-border-radius: $border-radius !default;
+
+
+// Modals
+
+// Padding applied to the modal body
+// $modal-inner-padding: 1rem !default;
+
+// $modal-dialog-margin        : .5rem !default;
+// $modal-dialog-margin-y-sm-up: 1.75rem !default;
+
+// $modal-title-line-height: $line-height-base !default;
+
+// $modal-content-color              : null !default;
+// $modal-content-bg                 : $white !default;
+// $modal-content-border-color       : rgba($black, .2) !default;
+// $modal-content-border-width       : $border-width !default;
+// $modal-content-border-radius      : $border-radius-lg !default;
+// $modal-content-inner-border-radius: calc(#{$modal-content-border-radius} - #{$modal-content-border-width}) !default;
+// $modal-content-box-shadow-xs      : 0 .25rem .5rem rgba($black, .5) !default;
+// $modal-content-box-shadow-sm-up   : 0 .5rem 1rem rgba($black, .5) !default;
+
+// $modal-backdrop-bg        : $black !default;
+// $modal-backdrop-opacity   : .5 !default;
+// $modal-header-border-color: $border-color !default;
+// $modal-footer-border-color: $modal-header-border-color !default;
+// $modal-header-border-width: $modal-content-border-width !default;
+// $modal-footer-border-width: $modal-header-border-width !default;
+// $modal-header-padding-y   : 1rem !default;
+// $modal-header-padding-x   : 1rem !default;
+// $modal-header-padding     : $modal-header-padding-y $modal-header-padding-x !default;  // Keep this for backwards compatibility
+
+// $modal-xl: 1140px !default;
+// $modal-lg: 800px !default;
+// $modal-md: 500px !default;
+// $modal-sm: 300px !default;
+
+// $modal-fade-transform: translate(0, -50px) !default;
+// $modal-show-transform: none !default;
+// $modal-transition    : transform .3s ease-out !default;
+
+
+// Alerts
 //
-//## Define the breakpoints at which your layout will change, adapting to different screen sizes.
-
-// Extra small screen / phone
-//** Deprecated `$screen-xs` as of v3.0.1
-$screen-xs:                  480px !default;
-//** Deprecated `$screen-xs-min` as of v3.2.0
-$screen-xs-min:              $screen-xs !default;
-//** Deprecated `$screen-phone` as of v3.0.1
-$screen-phone:               $screen-xs-min !default;
-
-// Small screen / tablet
-//** Deprecated `$screen-sm` as of v3.0.1
-$screen-sm:                  768px !default;
-$screen-sm-min:              $screen-sm !default;
-//** Deprecated `$screen-tablet` as of v3.0.1
-$screen-tablet:              $screen-sm-min !default;
-
-// Medium screen / desktop
-//** Deprecated `$screen-md` as of v3.0.1
-$screen-md:                  992px !default;
-$screen-md-min:              $screen-md !default;
-//** Deprecated `$screen-desktop` as of v3.0.1
-$screen-desktop:             $screen-md-min !default;
-
-// Large screen / wide desktop
-//** Deprecated `$screen-lg` as of v3.0.1
-$screen-lg:                  1200px !default;
-$screen-lg-min:              $screen-lg !default;
-//** Deprecated `$screen-lg-desktop` as of v3.0.1
-$screen-lg-desktop:          $screen-lg-min !default;
-
-// So media queries don't overlap when required, provide a maximum
-$screen-xs-max:              ($screen-sm-min - 1) !default;
-$screen-sm-max:              ($screen-md-min - 1) !default;
-$screen-md-max:              ($screen-lg-min - 1) !default;
-
-
-//== Grid system
-//
-//## Define your custom responsive grid.
-
-//** Number of columns in the grid.
-$grid-columns:              12 !default;
-//** Padding between columns. Gets divided in half for the left and right.
-$grid-gutter-width:         30px !default;
-// Navbar collapse
-//** Point at which the navbar becomes uncollapsed.
-$grid-float-breakpoint:     $screen-sm-min !default;
-//** Point at which the navbar begins collapsing.
-$grid-float-breakpoint-max: ($grid-float-breakpoint - 1) !default;
-
-
-//== Container sizes
-//
-//## Define the maximum width of `.container` for different screen sizes.
-
-// Small screen / tablet
-$container-tablet:             (720px + $grid-gutter-width) !default;
-//** For `$screen-sm-min` and up.
-$container-sm:                 $container-tablet !default;
-
-// Medium screen / desktop
-$container-desktop:            (940px + $grid-gutter-width) !default;
-//** For `$screen-md-min` and up.
-$container-md:                 $container-desktop !default;
-
-// Large screen / wide desktop
-$container-large-desktop:      (1140px + $grid-gutter-width) !default;
-//** For `$screen-lg-min` and up.
-$container-lg:                 $container-large-desktop !default;
-
-
-//== Navbar
-//
-//##
-
-// Basics of a navbar
-$navbar-height:                    50px !default;
-$navbar-margin-bottom:             $line-height-computed !default;
-$navbar-border-radius:             $border-radius-base !default;
-$navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;
-$navbar-padding-vertical:          (($navbar-height - $line-height-computed) / 2) !default;
-$navbar-collapse-max-height:       340px !default;
-
-$navbar-default-color:             #777 !default;
-$navbar-default-bg:                #f8f8f8 !default;
-$navbar-default-border:            darken($navbar-default-bg, 6.5%) !default;
-
-// Navbar links
-$navbar-default-link-color:                #777 !default;
-$navbar-default-link-hover-color:          #333 !default;
-$navbar-default-link-hover-bg:             transparent !default;
-$navbar-default-link-active-color:         #555 !default;
-$navbar-default-link-active-bg:            darken($navbar-default-bg, 6.5%) !default;
-$navbar-default-link-disabled-color:       #ccc !default;
-$navbar-default-link-disabled-bg:          transparent !default;
-
-// Navbar brand label
-$navbar-default-brand-color:               $navbar-default-link-color !default;
-$navbar-default-brand-hover-color:         darken($navbar-default-brand-color, 10%) !default;
-$navbar-default-brand-hover-bg:            transparent !default;
+// Define alert colors, border radius, and padding.
 
-// Navbar toggle
-$navbar-default-toggle-hover-bg:           #ddd !default;
-$navbar-default-toggle-icon-bar-bg:        #888 !default;
-$navbar-default-toggle-border-color:       #ddd !default;
+// $alert-padding-y       : .75rem !default;
+// $alert-padding-x       : 1.25rem !default;
+// $alert-margin-bottom   : 1rem !default;
+// $alert-border-radius   : $border-radius !default;
+// $alert-link-font-weight: $font-weight-bold !default;
+// $alert-border-width    : $border-width !default;
 
+// $alert-bg-level    : -10 !default;
+// $alert-border-level: -9 !default;
+// $alert-color-level : 6 !default;
 
-//=== Inverted navbar
-// Reset inverted navbar basics
-$navbar-inverse-color:                      lighten($gray-light, 15%) !default;
-$navbar-inverse-bg:                         #222 !default;
-$navbar-inverse-border:                     darken($navbar-inverse-bg, 10%) !default;
 
-// Inverted navbar links
-$navbar-inverse-link-color:                 lighten($gray-light, 15%) !default;
-$navbar-inverse-link-hover-color:           #fff !default;
-$navbar-inverse-link-hover-bg:              transparent !default;
-$navbar-inverse-link-active-color:          $navbar-inverse-link-hover-color !default;
-$navbar-inverse-link-active-bg:             darken($navbar-inverse-bg, 10%) !default;
-$navbar-inverse-link-disabled-color:        #444 !default;
-$navbar-inverse-link-disabled-bg:           transparent !default;
+// Progress bars
 
-// Inverted navbar brand label
-$navbar-inverse-brand-color:                $navbar-inverse-link-color !default;
-$navbar-inverse-brand-hover-color:          #fff !default;
-$navbar-inverse-brand-hover-bg:             transparent !default;
+// $progress-height              : 1rem !default;
+// $progress-font-size           : $font-size-base * .75 !default;
+// $progress-bg                  : $gray-200 !default;
+// $progress-border-radius       : $border-radius !default;
+// $progress-box-shadow          : inset 0 .1rem .1rem rgba($black, .1) !default;
+// $progress-bar-color           : $white !default;
+// $progress-bar-bg              : theme-color("primary") !default;
+// $progress-bar-animation-timing: 1s linear infinite !default;
+// $progress-bar-transition      : width .6s ease !default;
 
-// Inverted navbar toggle
-$navbar-inverse-toggle-hover-bg:            #333 !default;
-$navbar-inverse-toggle-icon-bar-bg:         #fff !default;
-$navbar-inverse-toggle-border-color:        #333 !default;
 
+// List group
 
-//== Navs
-//
-//##
+// $list-group-color        : null !default;
+// $list-group-bg           : $white !default;
+// $list-group-border-color : rgba($black, .125) !default;
+// $list-group-border-width : $border-width !default;
+// $list-group-border-radius: $border-radius !default;
 
-//=== Shared nav styles
-$nav-link-padding:                          10px 15px !default;
-$nav-link-hover-bg:                         $gray-lighter !default;
+// $list-group-item-padding-y: .75rem !default;
+// $list-group-item-padding-x: 1.25rem !default;
 
-$nav-disabled-link-color:                   $gray-light !default;
-$nav-disabled-link-hover-color:             $gray-light !default;
+// $list-group-hover-bg           : $gray-100 !default;
+// $list-group-active-color       : $component-active-color !default;
+// $list-group-active-bg          : $component-active-bg !default;
+// $list-group-active-border-color: $list-group-active-bg !default;
 
-//== Tabs
-$nav-tabs-border-color:                     #ddd !default;
+// $list-group-disabled-color: $gray-600 !default;
+// $list-group-disabled-bg   : $list-group-bg !default;
 
-$nav-tabs-link-hover-border-color:          $gray-lighter !default;
+// $list-group-action-color      : $gray-700 !default;
+// $list-group-action-hover-color: $list-group-action-color !default;
 
-$nav-tabs-active-link-hover-bg:             $body-bg !default;
-$nav-tabs-active-link-hover-color:          $gray !default;
-$nav-tabs-active-link-hover-border-color:   #ddd !default;
+// $list-group-action-active-color: $body-color !default;
+// $list-group-action-active-bg   : $gray-200 !default;
 
-$nav-tabs-justified-link-border-color:            #ddd !default;
-$nav-tabs-justified-active-link-border-color:     $body-bg !default;
 
-//== Pills
-$nav-pills-border-radius:                   $border-radius-base !default;
-$nav-pills-active-link-hover-bg:            $component-active-bg !default;
-$nav-pills-active-link-hover-color:         $component-active-color !default;
+// Image thumbnails
 
+// $thumbnail-padding      : .25rem !default;
+// $thumbnail-bg           : $body-bg !default;
+// $thumbnail-border-width : $border-width !default;
+// $thumbnail-border-color : $gray-300 !default;
+// $thumbnail-border-radius: $border-radius !default;
+// $thumbnail-box-shadow   : 0 1px 2px rgba($black, .075) !default;
 
-//== Pagination
-//
-//##
 
-$pagination-color:                     $link-color !default;
-$pagination-bg:                        #fff !default;
-$pagination-border:                    #ddd !default;
+// Figures
 
-$pagination-hover-color:               $link-hover-color !default;
-$pagination-hover-bg:                  $gray-lighter !default;
-$pagination-hover-border:              #ddd !default;
+// $figure-caption-font-size: 90% !default;
+// $figure-caption-color    : $gray-600 !default;
 
-$pagination-active-color:              #fff !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
 
-$pagination-disabled-color:            $gray-light !default;
-$pagination-disabled-bg:               #fff !default;
-$pagination-disabled-border:           #ddd !default;
+// Breadcrumbs
 
+// $breadcrumb-padding-y     : .75rem !default;
+// $breadcrumb-padding-x     : 1rem !default;
+// $breadcrumb-item-padding-x: .5rem !default;
 
-//== Pager
-//
-//##
+// $breadcrumb-margin-bottom: 1rem !default;
 
-$pager-bg:                             $pagination-bg !default;
-$pager-border:                         $pagination-border !default;
-$pager-border-radius:                  15px !default;
+// $breadcrumb-bg           : $gray-200 !default;
+// $breadcrumb-divider-color: $gray-600 !default;
+// $breadcrumb-active-color : $gray-600 !default;
+// $breadcrumb-divider      : quote("/") !default;
 
-$pager-hover-bg:                       $pagination-hover-bg !default;
+// $breadcrumb-border-radius: $border-radius !default;
 
-$pager-active-bg:                      $pagination-active-bg !default;
-$pager-active-color:                   $pagination-active-color !default;
 
-$pager-disabled-color:                 $pagination-disabled-color !default;
+// Carousel
 
+// $carousel-control-color        : $white !default;
+// $carousel-control-width        : 15% !default;
+// $carousel-control-opacity      : .5 !default;
+// $carousel-control-hover-opacity: .9 !default;
+// $carousel-control-transition   : opacity .15s ease !default;
 
-//== Jumbotron
-//
-//##
+// $carousel-indicator-width          : 30px !default;
+// $carousel-indicator-height         : 3px !default;
+// $carousel-indicator-hit-area-height: 10px !default;
+// $carousel-indicator-spacer         : 3px !default;
+// $carousel-indicator-active-bg      : $white !default;
+// $carousel-indicator-transition     : opacity .6s ease !default;
 
-$jumbotron-padding:              30px !default;
-$jumbotron-color:                inherit !default;
-$jumbotron-bg:                   $gray-lighter !default;
-$jumbotron-heading-color:        inherit !default;
-$jumbotron-font-size:            ceil(($font-size-base * 1.5)) !default;
-$jumbotron-heading-font-size:    ceil(($font-size-base * 4.5)) !default;
+// $carousel-caption-width: 70% !default;
+// $carousel-caption-color: $white !default;
 
+// $carousel-control-icon-width: 20px !default;
 
-//== Form states and alerts
-//
-//## Define colors for form feedback states and, by default, alerts.
+// $carousel-control-prev-icon-bg: str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-control-color}' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3e%3c/svg%3e"), "#", "%23") !default;
+// $carousel-control-next-icon-bg: str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-control-color}' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e"), "#", "%23") !default;
 
-$state-success-text:             #3c763d !default;
-$state-success-bg:               #dff0d8 !default;
-$state-success-border:           darken(adjust-hue($state-success-bg, -10), 5%) !default;
+// $carousel-transition-duration: .6s !default;
+// $carousel-transition         : transform $carousel-transition-duration ease-in-out !default;  // Define transform transition first if using multiple transitions (e.g., `transform 2s ease, opacity .5s ease-out`)
 
-$state-info-text:                #31708f !default;
-$state-info-bg:                  #d9edf7 !default;
-$state-info-border:              darken(adjust-hue($state-info-bg, -10), 7%) !default;
 
-$state-warning-text:             #8a6d3b !default;
-$state-warning-bg:               #fcf8e3 !default;
-$state-warning-border:           darken(adjust-hue($state-warning-bg, -10), 5%) !default;
-
-$state-danger-text:              #a94442 !default;
-$state-danger-bg:                #f2dede !default;
-$state-danger-border:            darken(adjust-hue($state-danger-bg, -10), 5%) !default;
-
-
-//== Tooltips
-//
-//##
+// Spinners
 
-//** Tooltip max width
-$tooltip-max-width:           200px !default;
-//** Tooltip text color
-$tooltip-color:               #fff !default;
-//** Tooltip background color
-$tooltip-bg:                  #000 !default;
-$tooltip-opacity:             .9 !default;
+// $spinner-width       : 2rem !default;
+// $spinner-height      : $spinner-width !default;
+// $spinner-border-width: .25em !default;
 
-//** Tooltip arrow width
-$tooltip-arrow-width:         5px !default;
-//** Tooltip arrow color
-$tooltip-arrow-color:         $tooltip-bg !default;
-
-
-//== Popovers
-//
-//##
-
-//** Popover body background color
-$popover-bg:                          #fff !default;
-//** Popover maximum width
-$popover-max-width:                   276px !default;
-//** Popover border color
-$popover-border-color:                rgba(0,0,0,.2) !default;
-//** Popover fallback border color
-$popover-fallback-border-color:       #ccc !default;
+// $spinner-width-sm       : 1rem !default;
+// $spinner-height-sm      : $spinner-width-sm !default;
+// $spinner-border-width-sm: .2em !default;
 
-//** Popover title background color
-$popover-title-bg:                    darken($popover-bg, 3%) !default;
 
-//** Popover arrow width
-$popover-arrow-width:                 10px !default;
-//** Popover arrow color
-$popover-arrow-color:                 $popover-bg !default;
-
-//** Popover outer arrow width
-$popover-arrow-outer-width:           ($popover-arrow-width + 1) !default;
-//** Popover outer arrow color
-$popover-arrow-outer-color:           fade_in($popover-border-color, 0.05) !default;
-//** Popover outer arrow fallback color
-$popover-arrow-outer-fallback-color:  darken($popover-fallback-border-color, 20%) !default;
-
-
-//== Labels
-//
-//##
-
-//** Default label background color
-$label-default-bg:            $gray-light !default;
-//** Primary label background color
-$label-primary-bg:            $brand-primary !default;
-//** Success label background color
-$label-success-bg:            $brand-success !default;
-//** Info label background color
-$label-info-bg:               $brand-info !default;
-//** Warning label background color
-$label-warning-bg:            $brand-warning !default;
-//** Danger label background color
-$label-danger-bg:             $brand-danger !default;
-
-//** Default label text color
-$label-color:                 #fff !default;
-//** Default text color of a linked label
-$label-link-hover-color:      #fff !default;
-
-
-//== Modals
-//
-//##
-
-//** Padding applied to the modal body
-$modal-inner-padding:         15px !default;
-
-//** Padding applied to the modal title
-$modal-title-padding:         15px !default;
-//** Modal title line-height
-$modal-title-line-height:     $line-height-base !default;
-
-//** Background color of modal content area
-$modal-content-bg:                             #fff !default;
-//** Modal content border color
-$modal-content-border-color:                   rgba(0,0,0,.2) !default;
-//** Modal content border color **for IE8**
-$modal-content-fallback-border-color:          #999 !default;
-
-//** Modal backdrop background color
-$modal-backdrop-bg:           #000 !default;
-//** Modal backdrop opacity
-$modal-backdrop-opacity:      .5 !default;
-//** Modal header border color
-$modal-header-border-color:   #e5e5e5 !default;
-//** Modal footer border color
-$modal-footer-border-color:   $modal-header-border-color !default;
-
-$modal-lg:                    900px !default;
-$modal-md:                    600px !default;
-$modal-sm:                    300px !default;
-
-
-//== Alerts
-//
-//## Define alert colors, border radius, and padding.
-
-$alert-padding:               15px !default;
-$alert-border-radius:         $border-radius-base !default;
-$alert-link-font-weight:      bold !default;
-
-$alert-success-bg:            $state-success-bg !default;
-$alert-success-text:          $state-success-text !default;
-$alert-success-border:        $state-success-border !default;
-
-$alert-info-bg:               $state-info-bg !default;
-$alert-info-text:             $state-info-text !default;
-$alert-info-border:           $state-info-border !default;
-
-$alert-warning-bg:            $state-warning-bg !default;
-$alert-warning-text:          $state-warning-text !default;
-$alert-warning-border:        $state-warning-border !default;
-
-$alert-danger-bg:             $state-danger-bg !default;
-$alert-danger-text:           $state-danger-text !default;
-$alert-danger-border:         $state-danger-border !default;
-
-
-//== Progress bars
-//
-//##
-
-//** Background color of the whole progress component
-$progress-bg:                 #f5f5f5 !default;
-//** Progress bar text color
-$progress-bar-color:          #fff !default;
-//** Variable for setting rounded corners on progress bar.
-$progress-border-radius:      $border-radius-base !default;
-
-//** Default progress bar color
-$progress-bar-bg:             $brand-primary !default;
-//** Success progress bar color
-$progress-bar-success-bg:     $brand-success !default;
-//** Warning progress bar color
-$progress-bar-warning-bg:     $brand-warning !default;
-//** Danger progress bar color
-$progress-bar-danger-bg:      $brand-danger !default;
-//** Info progress bar color
-$progress-bar-info-bg:        $brand-info !default;
-
-
-//== List group
-//
-//##
-
-//** Background color on `.list-group-item`
-$list-group-bg:                 #fff !default;
-//** `.list-group-item` border color
-$list-group-border:             #ddd !default;
-//** List group border radius
-$list-group-border-radius:      $border-radius-base !default;
-
-//** Background color of single list items on hover
-$list-group-hover-bg:           #f5f5f5 !default;
-//** Text color of active list items
-$list-group-active-color:       $component-active-color !default;
-//** Background color of active list items
-$list-group-active-bg:          $component-active-bg !default;
-//** Border color of active list elements
-$list-group-active-border:      $list-group-active-bg !default;
-//** Text color for content within active list items
-$list-group-active-text-color:  lighten($list-group-active-bg, 40%) !default;
-
-//** Text color of disabled list items
-$list-group-disabled-color:      $gray-light !default;
-//** Background color of disabled list items
-$list-group-disabled-bg:         $gray-lighter !default;
-//** Text color for content within disabled list items
-$list-group-disabled-text-color: $list-group-disabled-color !default;
-
-$list-group-link-color:         #555 !default;
-$list-group-link-hover-color:   $list-group-link-color !default;
-$list-group-link-heading-color: #333 !default;
-
-
-//== Panels
-//
-//##
-
-$panel-bg:                    #fff !default;
-$panel-body-padding:          15px !default;
-$panel-heading-padding:       10px 15px !default;
-$panel-footer-padding:        $panel-heading-padding !default;
-$panel-border-radius:         $border-radius-base !default;
-
-//** Border color for elements within panels
-$panel-inner-border:          #ddd !default;
-$panel-footer-bg:             #f5f5f5 !default;
-
-$panel-default-text:          $gray-dark !default;
-$panel-default-border:        #ddd !default;
-$panel-default-heading-bg:    #f5f5f5 !default;
-
-$panel-primary-text:          #fff !default;
-$panel-primary-border:        $brand-primary !default;
-$panel-primary-heading-bg:    $brand-primary !default;
-
-$panel-success-text:          $state-success-text !default;
-$panel-success-border:        $state-success-border !default;
-$panel-success-heading-bg:    $state-success-bg !default;
-
-$panel-info-text:             $state-info-text !default;
-$panel-info-border:           $state-info-border !default;
-$panel-info-heading-bg:       $state-info-bg !default;
-
-$panel-warning-text:          $state-warning-text !default;
-$panel-warning-border:        $state-warning-border !default;
-$panel-warning-heading-bg:    $state-warning-bg !default;
-
-$panel-danger-text:           $state-danger-text !default;
-$panel-danger-border:         $state-danger-border !default;
-$panel-danger-heading-bg:     $state-danger-bg !default;
-
-
-//== Thumbnails
-//
-//##
-
-//** Padding around the thumbnail image
-$thumbnail-padding:           4px !default;
-//** Thumbnail background color
-$thumbnail-bg:                $body-bg !default;
-//** Thumbnail border color
-$thumbnail-border:            #ddd !default;
-//** Thumbnail border radius
-$thumbnail-border-radius:     $border-radius-base !default;
-
-//** Custom text color for thumbnail captions
-$thumbnail-caption-color:     $text-color !default;
-//** Padding around the thumbnail caption
-$thumbnail-caption-padding:   9px !default;
-
-
-//== Wells
-//
-//##
-
-$well-bg:                     #f5f5f5 !default;
-$well-border:                 darken($well-bg, 7%) !default;
-
-
-//== Badges
-//
-//##
-
-$badge-color:                 #fff !default;
-//** Linked badge text color on hover
-$badge-link-hover-color:      #fff !default;
-$badge-bg:                    $gray-light !default;
-
-//** Badge text color in active nav link
-$badge-active-color:          $link-color !default;
-//** Badge background color in active nav link
-$badge-active-bg:             #fff !default;
-
-$badge-font-weight:           bold !default;
-$badge-line-height:           1 !default;
-$badge-border-radius:         10px !default;
-
-
-//== Breadcrumbs
-//
-//##
-
-$breadcrumb-padding-vertical:   8px !default;
-$breadcrumb-padding-horizontal: 15px !default;
-//** Breadcrumb background color
-$breadcrumb-bg:                 #f5f5f5 !default;
-//** Breadcrumb text color
-$breadcrumb-color:              #ccc !default;
-//** Text color of current page in the breadcrumb
-$breadcrumb-active-color:       $gray-light !default;
-//** Textual separator for between breadcrumb elements
-$breadcrumb-separator:          "/" !default;
-
-
-//== Carousel
-//
-//##
-
-$carousel-text-shadow:                        0 1px 2px rgba(0,0,0,.6) !default;
-
-$carousel-control-color:                      #fff !default;
-$carousel-control-width:                      15% !default;
-$carousel-control-opacity:                    .5 !default;
-$carousel-control-font-size:                  20px !default;
-
-$carousel-indicator-active-bg:                #fff !default;
-$carousel-indicator-border-color:             #fff !default;
-
-$carousel-caption-color:                      #fff !default;
-
-
-//== Close
-//
-//##
-
-$close-font-weight:           bold !default;
-$close-color:                 #000 !default;
-$close-text-shadow:           0 1px 0 #fff !default;
-
-
-//== Code
-//
-//##
-
-$code-color:                  #c7254e !default;
-$code-bg:                     #f9f2f4 !default;
-
-$kbd-color:                   #fff !default;
-$kbd-bg:                      #333 !default;
-
-$pre-bg:                      #f5f5f5 !default;
-$pre-color:                   $gray-dark !default;
-$pre-border-color:            #ccc !default;
-$pre-scrollable-max-height:   340px !default;
-
-
-//== Type
-//
-//##
-
-//** Horizontal offset for forms and lists.
-$component-offset-horizontal: 180px !default;
-//** Text muted color
-$text-muted:                  $gray-light !default;
-//** Abbreviations and acronyms border color
-$abbr-border-color:           $gray-light !default;
-//** Headings small color
-$headings-small-color:        $gray-light !default;
-//** Blockquote small color
-$blockquote-small-color:      $gray-light !default;
-//** Blockquote font size
-$blockquote-font-size:        ($font-size-base * 1.25) !default;
-//** Blockquote border color
-$blockquote-border-color:     $gray-lighter !default;
-//** Page header border color
-$page-header-border-color:    $gray-lighter !default;
-//** Width of horizontal description list titles
-$dl-horizontal-offset:        $component-offset-horizontal !default;
-//** Point at which .dl-horizontal becomes horizontal
-$dl-horizontal-breakpoint:    $grid-float-breakpoint !default;
-//** Horizontal line color.
-$hr-border:                   $gray-lighter !default;
+// Close
+
+// $close-font-size  : $font-size-base * 1.5 !default;
+// $close-font-weight: $font-weight-bold !default;
+// $close-color      : $black !default;
+// $close-text-shadow: 0 1px 0 $white !default;
+
+
+// Code
+
+// $code-font-size: 87.5% !default;
+// $code-color    : $pink !default;
+
+// $kbd-padding-y: .2rem !default;
+// $kbd-padding-x: .4rem !default;
+// $kbd-font-size: $code-font-size !default;
+// $kbd-color    : $white !default;
+// $kbd-bg       : $gray-900 !default;
+
+// $pre-color                : null !default;
+// $pre-scrollable-max-height: 340px !default;

--- a/src/CLI/Scaffolding/Presets/stubs/bootstrap/resources/assets/sass/bootstrap.scss
+++ b/src/CLI/Scaffolding/Presets/stubs/bootstrap/resources/assets/sass/bootstrap.scss
@@ -9,54 +9,41 @@
 // Bootstrap
 // ==============================================================
 // Import Bootstrap framework and its dependences.
-
-// Core variables and mixins
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/mixins';
-
-// Reset and dependencies
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/normalize';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/print';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/glyphicons';
-
-// Core CSS
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/scaffolding';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/type';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/code';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/grid';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/tables';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/forms';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/buttons';
-
-// Components
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/component-animations';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/dropdowns';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/button-groups';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/input-groups';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/navs';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/navbar';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/breadcrumbs';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/pagination';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/pager';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/labels';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/badges';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/jumbotron';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/thumbnails';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/alerts';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/progress-bars';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/media';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/list-group';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/panels';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/responsive-embed';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/wells';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/close';
-
-// Components w/ JavaScript
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/modals';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/tooltip';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/popovers';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/carousel';
-
-// Utility classes
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/utilities';
-@import '~bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities';
+// Uncomment what you don't need to get smaller bundle size
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/root";
+@import "~bootstrap/scss/reboot";
+@import "~bootstrap/scss/type";
+@import "~bootstrap/scss/images";
+@import "~bootstrap/scss/code";
+@import "~bootstrap/scss/grid";
+@import "~bootstrap/scss/tables";
+@import "~bootstrap/scss/forms";
+@import "~bootstrap/scss/buttons";
+@import "~bootstrap/scss/transitions";
+@import "~bootstrap/scss/dropdown";
+@import "~bootstrap/scss/button-group";
+@import "~bootstrap/scss/input-group";
+@import "~bootstrap/scss/custom-forms";
+@import "~bootstrap/scss/nav";
+@import "~bootstrap/scss/navbar";
+@import "~bootstrap/scss/card";
+@import "~bootstrap/scss/breadcrumb";
+@import "~bootstrap/scss/pagination";
+@import "~bootstrap/scss/badge";
+@import "~bootstrap/scss/jumbotron";
+@import "~bootstrap/scss/alert";
+@import "~bootstrap/scss/progress";
+@import "~bootstrap/scss/media";
+@import "~bootstrap/scss/list-group";
+@import "~bootstrap/scss/close";
+@import "~bootstrap/scss/toasts";
+@import "~bootstrap/scss/modal";
+@import "~bootstrap/scss/tooltip";
+@import "~bootstrap/scss/popover";
+@import "~bootstrap/scss/carousel";
+@import "~bootstrap/scss/spinners";
+@import "~bootstrap/scss/utilities";
+@import "~bootstrap/scss/print";

--- a/tests/features/Scaffolding/BootstrapTest.php
+++ b/tests/features/Scaffolding/BootstrapTest.php
@@ -8,7 +8,7 @@ class BootstrapTest extends StubsCase
     {
         (new Scaffolder($this->destination))->build('bootstrap');
 
-        $this->assertFileContains('bootstrap-sass', "{$this->destination}/package.json");
+        $this->assertFileContains('bootstrap', "{$this->destination}/package.json");
     }
 
     public function test_updating_config()


### PR DESCRIPTION
At the moment Tonik preset for Bootstrap comes with 3.3.7 but Bootstrap 4 is officially released a long time ago. So I updated the needed files to version 4.3.1 what is the current version today.